### PR TITLE
Fix if condition

### DIFF
--- a/src/sequences.js
+++ b/src/sequences.js
@@ -105,8 +105,7 @@ const get = [
         let conn = get(
           state`oada.${request.connection_id || props.connection_id}`
         );
-        if (!conn) {
-          if (conn && conn.watches && conn.watches[request.path]) return;
+        if (conn && !(conn.watches && conn.watches[request.path])) {
           request.watch.signals = [
             "oada.handleWatch",
             ...request.watch.signals,


### PR DESCRIPTION
This pull request fixes the if conditions in lines 108-109. The `return` statement on line 109 of the original code is never called because `conn` is not `true`.