### PR TITLE
Update oada-cache dep to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "oada",
   "license": "Apache-2.0",
   "dependencies": {
-    "@oada/oada-cache": "^3.1.6",
+    "@oada/oada-cache": "^4.0.0",
     "debug": "^4.1.0",
     "fs": "^0.0.1-security",
     "lodash": "^4.17.15",


### PR DESCRIPTION
Needed to use with OADAv2 due to returning success/200 issue. Does `yarn.lock` need to be updated too?

Will npm be updated automatically or does that need to be triggered manually?